### PR TITLE
Issue 31 fix

### DIFF
--- a/Controls/BrowsableFileTextBox.axaml.cs
+++ b/Controls/BrowsableFileTextBox.axaml.cs
@@ -66,10 +66,10 @@ public partial class BrowsableFileTextBox : UserControl
                 FileTypeFilter = new List<FilePickerFileType>
                 {
                     new("All Files") { Patterns = new[] { "*" } },
-                    new("Model Files") { Patterns = new[] { "*.blend", "*.obj", "*.stl" } },
-                    new("Blender Files") { Patterns = new[] { "*.blend" } },
-                    new("OBJ Files") { Patterns = new[] { "*.obj" } },
-                    new("STL Files") { Patterns = new[] { "*.stl" } },
+                    new("Model Files") { Patterns = new[] { "*.blend", "*.obj", "*.stl", "*.BLEND", "*.OBJ", "*.STL" } },
+                    new("Blender Files") { Patterns = new[] { "*.blend", "*.BLEND" } },
+                    new("OBJ Files") { Patterns = new[] { "*.obj", "*.OBJ" } },
+                    new("STL Files") { Patterns = new[] { "*.stl", "*.STL" } },
                 },
             }
         );

--- a/Pages/ModelPage.axaml.cs
+++ b/Pages/ModelPage.axaml.cs
@@ -40,7 +40,7 @@ public partial class ModelPage : UserControl
     /// <summary>
     /// List of valid file types for models.
     /// </summary>
-    private static readonly List<string> ValidTypes = [".blend", ".obj", ".stl"];
+    private static readonly List<string> ValidTypes = [".blend", ".obj", ".stl", ".BLEND", ".OBJ", ".STL"];
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // INITIALIZATION
@@ -280,7 +280,7 @@ public partial class ModelPage : UserControl
 
         // Get the dimensions of the model
         Vector3 dimensions;
-        switch (extension)
+        switch (extension.ToLower())
         {
             case ".obj":
                 dimensions = ModelManager.GetObjDimensions(modelPath);


### PR DESCRIPTION
Bug Fix: Fixed issue where when measuring a model, the program would attempt to determine if the model was a .stl, .obj, or .blend file, but the detection was case sensitive. If the file extension was not lowercase, the program would fail to recognize it as a valid model file type, even if it was.  

More Details: 
- When dealing with extensions convert them to lowercase before processing them. - Added uppercase variants to valid file types.